### PR TITLE
Fix tgenv install for Windows

### DIFF
--- a/libexec/tgenv-install
+++ b/libexec/tgenv-install
@@ -43,13 +43,13 @@ case "$(uname -s)" in
     os="darwin_${TGENV_ARCH}"
     ;;
   MINGW64*)
-    os="windows_${TGENV_ARCH}"
+    os="windows_${TGENV_ARCH}.exe"
     ;;
   MSYS_NT*)
-    os="windows_${TGENV_ARCH}"
+    os="windows_${TGENV_ARCH}.exe"
     ;;
   CYGWIN_NT*)
-    os="windows_${TGENV_ARCH}"
+    os="windows_${TGENV_ARCH}.exe"
     ;;
   *)
     os="linux_${TGENV_ARCH}"


### PR DESCRIPTION
It's missing `.exe` from the download location.

I'm supporting a few Windows 10 users and I've found this issue during my testing.

```bash
$ tgenv install 0.21.6
[INFO] Installing Terragrunt v0.21.6
[INFO] Downloading release tarball from https://github.com/gruntwork-io/terragrunt/releases/download/v0.21.6/terragrunt_windows_amd64
curl: (22) The requested URL returned error: 404 Not Found

tgenv: tgenv-install: [ERROR] Tarball download failed
```